### PR TITLE
Handle board members in repeated nonpartisan section

### DIFF
--- a/elections/helpers.py
+++ b/elections/helpers.py
@@ -476,6 +476,10 @@ def parse_general_election_offices(ballot: BeautifulSoup, data: Dict) -> int:
         elif "office" in item['class']:
             label = titleize(item.text)
             if division is None:
+                if label == "Board Member":
+                    # TODO: https://mvic.sos.state.mi.us/Voter/GetMvicBallot/256/683/
+                    log.error(f'Section missing for office: {label}')
+                    return count
                 assert (
                     label == "Library Board Director"
                 ), f'Division missing for office: {label}'

--- a/tests/test_scrape_and_parse.py
+++ b/tests/test_scrape_and_parse.py
@@ -39,6 +39,7 @@ def parse_ballot(election_id: int, precinct_id: int) -> int:
         (683, 901, 17),
         (683, 133, 18),
         (683, 268, 12),
+        (683, 256, 3),  # TODO: handle divisionless board members
     ],
 )
 def test_ballots(expect, db, election_id, precinct_id, item_count):


### PR DESCRIPTION
https://mvic.sos.state.mi.us/Voter/GetMvicBallot/256/683/ is currently malformed:

![](https://cdn.zappy.app/e422cc8c35c3963400b2e2854d31c5d9.png)

The second board member is in a repeated section with no district information.

